### PR TITLE
Added preloading to H2p initialization

### DIFF
--- a/h2p_parser/h2p.py
+++ b/h2p_parser/h2p.py
@@ -22,7 +22,7 @@ def format_phonemes(phoneme_str):
 
 
 # Method to use Regex to replace the first instance of a word with its phonemes
-def replace(target, replacement, text):
+def format_ph(target, replacement, text):
     # Replace the first instance of a word with its phonemes
     return re.sub(r'\b' + target + r'\b', replacement, text, 1)
 
@@ -62,7 +62,7 @@ class H2p:
             # Format phonemes
             f_ph = format_phonemes(phonemes)
             # Replace word with phonemes
-            text = replace(word, f_ph, text)
+            text = format_ph(word, f_ph, text)
         return text
 
     # Replaces heteronyms in a list of text lines
@@ -86,6 +86,6 @@ class H2p:
                 # Format phonemes
                 f_ph = format_phonemes(phonemes)
                 # Replace word with phonemes
-                text_list[index] = replace(word, f_ph, text_list[index])
+                text_list[index] = format_ph(word, f_ph, text_list[index])
         return text_list
 

--- a/h2p_parser/h2p.py
+++ b/h2p_parser/h2p.py
@@ -28,9 +28,25 @@ def format_ph(target, replacement, text):
 
 
 class H2p:
-    def __init__(self, dict_path=None):
+    def __init__(self, dict_path=None, preload=False):
+        """
+        Creates a H2p parser
+
+        :param dict_path: Path to a heteronym dictionary json file. Built-in dictionary will be used if None
+        :type dict_path: str
+        :param preload: Preloads the tokenizer and tagger during initialization
+        :type preload: bool
+        """
         self.dict = Dictionary(dict_path)
         self.tokenize = TweetTokenizer().tokenize
+        if preload:
+            self.preload()
+
+    # Method to preload tokenizer and pos_tag
+    def preload(self):
+        tokens = self.tokenize('a')
+        assert tokens == ['a']
+        assert pos_tag(tokens)[0][0] == 'a'
 
     # Method to check if a text line contains a heteronym
     def contains_het(self, text):

--- a/tests/perf.py
+++ b/tests/perf.py
@@ -65,10 +65,13 @@ class Perf:
         """
         self.h2p = self.get_h2p()
 
+    # noinspection PyUnusedLocal
     @patch('h2p_parser.dictionary.exists', side_effect=always_exists)
     def get_h2p(self, exists_function):
         with patch('builtins.open', mock_open(read_data=self.file_mock_content)):
-            return H2p("path/to/open")
+            result = H2p("path/to/open")
+        result.preload()
+        return result
 
     # Measuring the performance of the replace_het function
     def test_performance_replace_het(self, n):


### PR DESCRIPTION
Added ability for H2p initialization to use preload=true or for preload() to be called to preload the tokenizer and pos tagger. This moves the time penalty to the initialization instead of on the first inference after object creation.