### PR TITLE
fix exception with backets in input text

### DIFF
--- a/h2p_parser/h2p.py
+++ b/h2p_parser/h2p.py
@@ -21,7 +21,7 @@ def replace_first(target, replacement, text):
     if target is None or target == '':
         return text
     # Replace the first instance of a word with its phonemes
-    return re.sub(r'(?i)\b' + target + r'\b', replacement, text, 1)
+    return re.sub(r'(?i)\b' + re.escape(target) + r'\b', replacement, text, 1)
 
 
 class H2p:


### PR DESCRIPTION
This line fails when input text contains brackets.

```python
Traceback (most recent call last):
  File "process_dataset.py", line 55, in <module>
    txt_chunk_arpa = CMUDictExt.convert(txt_chunk)
  File "/media/cookie/SN850/pngnw_bert/pngnwbert/h2p_parser/cmudictext.py", line 290, in convert
    text = replace_first(word, f_ph, text)
  File "/media/cookie/SN850/pngnw_bert/pngnwbert/h2p_parser/h2p.py", line 24, in replace_first
    return re.sub(r'(?i)\b' + target + r'\b', replacement, text, 1)
  File "/home/cookie/anaconda3/lib/python3.8/re.py", line 210, in sub
    return _compile(pattern, flags).sub(repl, string, count)
  File "/home/cookie/anaconda3/lib/python3.8/re.py", line 304, in _compile
    p = sre_compile.compile(pattern, flags)
  File "/home/cookie/anaconda3/lib/python3.8/sre_compile.py", line 764, in compile
    p = sre_parse.parse(p, flags)
  File "/home/cookie/anaconda3/lib/python3.8/sre_parse.py", line 948, in parse
    p = _parse_sub(source, state, flags & SRE_FLAG_VERBOSE, 0)
  File "/home/cookie/anaconda3/lib/python3.8/sre_parse.py", line 443, in _parse_sub
    itemsappend(_parse(source, state, verbose, nested + 1,
  File "/home/cookie/anaconda3/lib/python3.8/sre_parse.py", line 836, in _parse
    raise source.error("missing ), unterminated subpattern",
re.error: missing ), unterminated subpattern at position 6
```

Simple fix is escaping any special characters inside the `target` variable.