### PR TITLE
Fix setuptools package discovery

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
-from setuptools import setup
+from setuptools import find_packages, setup
 
 setup(
     name='h2p_parser',
     version='1.0.0',
-    packages=[''],
-    package_dir={'': 'h2p_parser'},
+    packages=find_packages(include=["h2p_parser*"]),
+    package_data={"h2p_parser.data": ["*.db", "*.dict", "*.json", "*.txt"]},
     install_requires=['nltk', 'inflect'],
     python_requires='>=3.7',
     url='https://github.com/ionite34/h2p-parser',


### PR DESCRIPTION
I tried to install this package on Python 3.9 with pip 23.3.1 and setuptools 68.2.2. It incorrectly installs the package into the root `site-packages` directory (instead of within an `h2p_parser` subdirectory). The module is not importable when installed this way.

I don't really know why setuptools installs it that way, but the config seemed relatively complex for what this package needs. `package_dir` seems unnecessary since the package is in the root directory:

> If your packages are not in the root of the repository or do not correspond exactly to the directory structure, you also need to configure package_dir:

(https://setuptools.pypa.io/en/latest/userguide/package_discovery.html)